### PR TITLE
bumping up the version number to 3.0.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "soundasleep-bootstrap-datetimepicker-sass",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": [
     "build/css/bootstrap-datetimepicker.min.css",
     "build/js/bootstrap-datetimepicker.min.js"

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-datetimepicker-sass",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": ["build/css/bootstrap-datetimepicker.min.css","build/js/bootstrap-datetimepicker.min.js"],
   "dependencies": {
     "jquery" : ">=1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-datetimepicker-sass",
   "filename": "js/bootstrap-datetimepicker.min.js",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/soundasleep/bootstrap-datetimepicker-sass.git"

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1,5 +1,5 @@
 /*
-Version 3.0.0
+Version 3.0.3
 =========================================================
 bootstrap-datetimepicker.js
 https://github.com/Eonasdan/bootstrap-datetimepicker


### PR DESCRIPTION
Hi,

was unable to get the latest version using bower update because the version number. in the mean time i have configured it to use the latest commit id so that i can get the latest.

I have created this pull request because i have updated the versions numbers and was hoping that you might be able run make against it as i can't as it crashes in windows and merge it into your master copy?

Thanks
Charlotte
