### PR TITLE
# Fixed for prev and next year button issue when we set minDate and m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Include necessary scripts and styles:
 2. The `make` file only generates from LESS, not SASS. It looks like there are no SASS compilation binaries for Windows... maybe need to use `grunt` for `grunt-sass`?
 3. There are no tests, not even an example HTML file to demonstrate how it works (I guess that's what the Github.io pages were for). It would be good to add them.
 4. An issue I'd like to fix: [Add options to disable displaying Months or Years views](https://github.com/Eonasdan/bootstrap-datetimepicker/issues/252)
+
+## Fix for prev and next year button issue when we set minDate and maxDate in options
+1. 'Next' Icon in date range filter is always disabled for year selection.
+2. 'Prev' Icon is not restricted based on minDate.

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -422,10 +422,10 @@ THE SOFTWARE.
             if (currentYear === year) {
                 months.eq(picker.date.month()).addClass('active');
             }
-            if (currentYear - 1 < startYear) {
+            if (year - 1 < startYear) {
                 picker.widget.find('.datepicker-months th:eq(0)').addClass('disabled');
             }
-            if (currentYear + 1 > endYear) {
+            if (year + 1 > endYear) {
                 picker.widget.find('.datepicker-months th:eq(2)').addClass('disabled');
             }
             for (i = 0; i < 12; i++) {


### PR DESCRIPTION
## Fix for prev and next year button issue when we set minDate and maxDate in options
1. 'Next' Icon in date range filter is always disabled for year selection.
2. 'Prev' Icon is not restricted based on minDate.
Changed from **"currentYear" to "year"** variable to give user to select perv and next year based on minDate and maxDate from options.

>  if (year - 1 < startYear) {
>                 picker.widget.find('.datepicker-months th:eq(0)').addClass('disabled');
>             }
>             if (year + 1 > endYear) {
>                 picker.widget.find('.datepicker-months th:eq(2)').addClass('disabled');
>             }

Please find the attached Image for reference.

![daterange](https://cloud.githubusercontent.com/assets/12742714/22545387/90e6bbd8-e95e-11e6-9cc6-c48977c04ca1.png)

Note: When you run makefile check bootstrap offical version is 3.3.7 
