### PR TITLE
Added support to hide the calendar when we hit escape key.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -777,6 +777,11 @@ THE SOFTWARE.
             if (!picker.isInput) {
                 $(document).on(
                     'mousedown.datetimepicker' + picker.id, $.proxy(picker.hide, this));
+                $(document).keyup(function (e) {
+                    if (e.keyCode == 27) { // escape key maps to keycode `27`
+                        picker.hide();
+                    }
+                });
             }
         },
 


### PR DESCRIPTION
The fix is related to calendar popup. When we click on calendar icon to open the calendar and if we click on escape from keyboard the calendar will not close. We have fixed it by escape key event.
This is the view when we click on calendar icon.

![datepicker](https://user-images.githubusercontent.com/10631443/27897458-0a20cb76-623e-11e7-9613-6aa24daa8cb2.png)

When we click on escape it will appear as below

![onlycalendarafterescape](https://user-images.githubusercontent.com/10631443/27897529-74fa6330-623e-11e7-8c7c-05f5ee89fda5.png)

We have fixed it by escape key event.